### PR TITLE
fix: remember me checkbox use boolean now

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email])
     if user && user.authenticate(params[:session][:password])
       log_in user
-      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
+      params[:session][:remember_me] ? remember(user) : forget(user)
       redirect_to me_url
     else
       flash.now[:error] = 'Invalid email/password combination'

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -10,7 +10,7 @@
       <%= f.password_field :password, class: 'form-control' %>
       
       <%= f.label :remember_me, class: "checkbox inline" do %>
-        <%= f.check_box :remember_me %>
+        <%= f.check_box :remember_me, { }, true, false %>
         <span> Remember me on this computer</span>
       <% end %>
 


### PR DESCRIPTION
Acceptance criteria:
- Remember me check box uses booleans instead of '1' and '0'