### PR TITLE
fix: move tokenizer methods from user model to a module

### DIFF
--- a/app/models/concerns/tokenizer.rb
+++ b/app/models/concerns/tokenizer.rb
@@ -1,0 +1,12 @@
+module Tokenizer
+  def digest(string)
+    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                   BCrypt::Engine::cost
+
+    BCrypt::Password.create(string, cost: cost)
+  end
+
+  def new_token
+    SecureRandom.urlsafe_base64
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,23 +1,12 @@
 class User < ApplicationRecord
+  extend Tokenizer
+
   attr_accessor :remember_token
 
   validates :username, :email, presence: true, uniqueness: true
   validates :email, email: true
   validates :password, confirmation: true
   has_secure_password
-
-  class << self
-    def digest(string)
-      cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
-                                                    BCrypt::Engine::cost
-  
-      BCrypt::Password.create(string, cost: cost)
-    end
-  
-    def new_token
-      SecureRandom.urlsafe_base64
-    end
-  end
 
   def remember
     self.remember_token = User.new_token


### PR DESCRIPTION
Acceptance Criteria:
- Placed module in models/concerns
- Extend makes classes methods as before the change